### PR TITLE
Make the color compatible with noice.nvim

### DIFF
--- a/colors/paper.vim
+++ b/colors/paper.vim
@@ -5,11 +5,9 @@
 " Website:      https://github.com/yorickpeterse/vim-paper.vim
 " License:      MPL 2.0
 
-if exists('g.colors_name')
-  highlight clear
-endif
-
 set background=light
+
+hi clear
 
 if exists('g:syntax_on')
   syntax reset
@@ -379,8 +377,6 @@ Hi NoiceCmdlinePopupTitle black NONE NONE
 Hi NoiceCmdlinePopupBorder black NONE NONE
 Hi NoiceCmdlineIcon black NONE NONE
 Hi NoiceCursor white black NONE
-" Hi NoiceFormatLevelInfo green NONE NONE
-" Hi NoicePopupBorder white white NONE
 Hi NoicePopup background background NONE
 
 delcommand Hi

--- a/colors/paper.vim
+++ b/colors/paper.vim
@@ -5,9 +5,11 @@
 " Website:      https://github.com/yorickpeterse/vim-paper.vim
 " License:      MPL 2.0
 
-set background=light
+if exists('g.colors_name')
+  highlight clear
+endif
 
-hi clear
+set background=light
 
 if exists('g:syntax_on')
   syntax reset
@@ -172,6 +174,11 @@ Hi Todo grey NONE bold
 Hi VertSplit lgrey2 NONE NONE
 Hi WarningMsg orange NONE bold
 Hi Underlined NONE NONE underline
+Hi DiagnosticInfo green NONE NONE
+Hi DiagnosticSignInfo green NONE NONE
+
+hi! link NotifyINFOIcon DiagnosticInfo
+hi! link NotifyINFOTitle DiagnosticInfo
 
 hi! link Boolean Keyword
 hi! link Character String
@@ -365,6 +372,16 @@ hi! link yamlPlainScalar String
 hi! link yardComment Comment
 hi! link yardType Todo
 hi! link yardTypeList Todo
+
+" Noice
+Hi NoiceCmdlinePopup black lbackground NONE
+Hi NoiceCmdlinePopupTitle black NONE NONE
+Hi NoiceCmdlinePopupBorder black NONE NONE
+Hi NoiceCmdlineIcon black NONE NONE
+Hi NoiceCursor white black NONE
+" Hi NoiceFormatLevelInfo green NONE NONE
+" Hi NoicePopupBorder white white NONE
+Hi NoicePopup background background NONE
 
 delcommand Hi
 


### PR DESCRIPTION
Thanks so much for the amazing theme! I've been looking for something like this for a long time :) 

I use LazyVim and [noice.nvim](https://github.com/folke/noice.nvim) is used by default. Unfortunately, some of the default colors of noice.nvim are incompatible with the yellowish background color, making it noice.nvim's cmdline and notification popups undreadable. This patch addresses them (minimally).

Please see the before and after screenshots below.

**Before**
<img width="1264" alt="Screenshot 2024-04-16 at 7 19 29 AM" src="https://github.com/yorickpeterse/vim-paper/assets/2296722/0fdb3f79-778b-4755-a6f0-3ca3a4520a09">


**After**
<img width="1264" alt="Screenshot 2024-04-16 at 7 19 58 AM" src="https://github.com/yorickpeterse/vim-paper/assets/2296722/4f99a6bd-944d-4278-9b5d-ec8bc6942f75">
