### PR TITLE
Fix noice popup unreadable

### DIFF
--- a/colors/paper.vim
+++ b/colors/paper.vim
@@ -377,7 +377,6 @@ Hi NoiceCmdlinePopupTitle black NONE NONE
 Hi NoiceCmdlinePopupBorder black NONE NONE
 Hi NoiceCmdlineIcon black NONE NONE
 Hi NoiceCursor white black NONE
-Hi NoicePopup background background NONE
 
 delcommand Hi
 


### PR DESCRIPTION
Following up on my PR earlier. There was an unecessary line that makes noice's popup unreadable (fg color = bg color). So, I'm removing that line in this PR. By default `NoicePopup` is [linked to](https://github.com/folke/noice.nvim?tab=readme-ov-file#-highlight-groups) `NormalFloat`, so this is the intended behavior.