### PR TITLE
Make LSP diagnostic warn & error colors explicit

### DIFF
--- a/colors/paper.vim
+++ b/colors/paper.vim
@@ -174,6 +174,8 @@ Hi WarningMsg orange NONE bold
 Hi Underlined NONE NONE underline
 Hi DiagnosticInfo green NONE NONE
 Hi DiagnosticSignInfo green NONE NONE
+Hi DiagnosticWarn orange NONE NONE
+Hi DiagnosticError red NONE NONE
 
 hi! link NotifyINFOIcon DiagnosticInfo
 hi! link NotifyINFOTitle DiagnosticInfo


### PR DESCRIPTION
In nvim 0.10, the LSP diagnostic colors default to black for some reason. This PR simply makes the colors explicit.

**Before (with nvim 0.10)**
<img width="1288" alt="Screenshot 2024-05-19 at 10 46 57 AM" src="https://github.com/yorickpeterse/vim-paper/assets/2296722/c8dbae91-a5f1-43ae-8414-5d5c7b5e619f">


**After (with nvim 0.10)**
<img width="1288" alt="Screenshot 2024-05-19 at 10 48 14 AM" src="https://github.com/yorickpeterse/vim-paper/assets/2296722/6de021db-6f5c-441d-8dbd-2cb7f1b93e4f">
