### PR TITLE
Remove ColorColumn

### DIFF
--- a/colors/paper.vim
+++ b/colors/paper.vim
@@ -126,7 +126,6 @@ endif
 " simply use its name (e.g. "black").
 
 " Generic highlight groups
-Hi ColorColumn NONE lbackground NONE
 Hi Comment grey NONE NONE
 Hi Conceal NONE NONE NONE
 Hi Constant black NONE NONE


### PR DESCRIPTION
This MR removes `ColorColumn` from the theme.

## Why
Because I'd like to set this to other colors to make it visible.

## Justification
I'm not really sure why this is presently part of the theme. I looked through the git log and it appears it used to be gray, which was a fine choice, but setting it to invisible (effectively) I don't understand. I am not aware of a popular plugin for Vim which sets this to a strange color - or at all, so this feels like it should be safe to remove.

