### PR TITLE
Make LspReferenceText yellow instead of gray

### DIFF
--- a/colors/paper.vim
+++ b/colors/paper.vim
@@ -287,6 +287,7 @@ hi! link luaFunction Keyword
 " LSP
 Hi LspDiagnosticsUnderlineError NONE NONE undercurl red
 Hi LspDiagnosticsUnderlineWarning NONE NONE undercurl yellow
+Hi LspReferenceText NONE lyellow NONE
 
 " Make
 hi! link makeTarget Function


### PR DESCRIPTION
![CleanShot 2024-10-29 at 15 49 46@2x](https://github.com/user-attachments/assets/a50ec3ee-3777-43d4-846b-149e731e3a48)

This makes LSP reference highlights yellow instead of gray. The main problem with them being gray by default is that it's the same color as visual highlight, so if your cursor is inside of a string, then the string will get a gray highlight and your visual selection will also be gray and you can't figure out which part is selected.