### PR TITLE
Colorize LspInlayHint

### DIFF
--- a/colors/paper.vim
+++ b/colors/paper.vim
@@ -288,6 +288,7 @@ hi! link luaFunction Keyword
 Hi LspDiagnosticsUnderlineError NONE NONE undercurl red
 Hi LspDiagnosticsUnderlineWarning NONE NONE undercurl yellow
 Hi LspReferenceText NONE lyellow NONE
+Hi LspInlayHint grey NONE NONE
 
 " Make
 hi! link makeTarget Function


### PR DESCRIPTION
This was defaulting to a very light color. This is the built-in neovim group for LspInlayHints that needed styling.

Before:

![CleanShot 2024-12-02 at 09 55 49@2x](https://github.com/user-attachments/assets/df7ba896-19c4-4df9-887a-91a050431ea4)

After:

![CleanShot 2024-12-02 at 09 55 09@2x](https://github.com/user-attachments/assets/a89d31b4-e8cb-404b-a074-684d71a2466d)
