### PR TITLE
Highlight NonText as grey instead of transparent

### DIFF
--- a/colors/paper.vim
+++ b/colors/paper.vim
@@ -143,7 +143,7 @@ Hi LineNr black NONE NONE
 Hi Macro orange NONE NONE
 Hi MatchParen NONE NONE bold
 Hi MoreMsg black NONE NONE
-Hi NonText background NONE NONE
+Hi NonText lgrey3 NONE NONE
 Hi Normal black background NONE
 Hi NormalFloat black background NONE
 Hi Bold black NONE bold


### PR DESCRIPTION
This was mainly for `snacks.picker`, which uses NonText for its default highlight of directory paths:

![CleanShot 2025-02-14 at 19 14 59@2x](https://github.com/user-attachments/assets/8cd3ae41-be72-41fa-928e-115ac341c7d8)

Before this change, this bit is transparent:

![CleanShot 2025-02-14 at 19 15 54@2x](https://github.com/user-attachments/assets/05cafaef-514f-4ba1-88c2-2a302a8736a2)

Per the neovim docs, this hlgroup is used for things like visible whitespace, so it should probably be visible in the colorscheme: https://neovim.io/doc/user/syntax.html